### PR TITLE
Add Uber-inspired theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 @custom-variant sunset (&:is(.sunset *));
 @custom-variant black (&:is(.black *));
+@custom-variant uber (&:is(.uber *));
 
 :root {
   --background: oklch(0.99 0.01 56.32);
@@ -183,6 +184,53 @@
   --font-sans: Montserrat, sans-serif;
   --font-serif: Merriweather, serif;
   --font-mono: Ubuntu Mono, monospace;
+  --radius: 0.625rem;
+  --shadow-2xs: 0px 6px 12px -3px hsl(0 0% 0% / 0.04);
+  --shadow-xs: 0px 6px 12px -3px hsl(0 0% 0% / 0.04);
+  --shadow-sm: 0px 6px 12px -3px hsl(0 0% 0% / 0.09), 0px 1px 2px -4px hsl(0 0% 0% / 0.09);
+  --shadow: 0px 6px 12px -3px hsl(0 0% 0% / 0.09), 0px 1px 2px -4px hsl(0 0% 0% / 0.09);
+  --shadow-md: 0px 6px 12px -3px hsl(0 0% 0% / 0.09), 0px 2px 4px -4px hsl(0 0% 0% / 0.09);
+  --shadow-lg: 0px 6px 12px -3px hsl(0 0% 0% / 0.09), 0px 4px 6px -4px hsl(0 0% 0% / 0.09);
+  --shadow-xl: 0px 6px 12px -3px hsl(0 0% 0% / 0.09), 0px 8px 10px -4px hsl(0 0% 0% / 0.09);
+  --shadow-2xl: 0px 6px 12px -3px hsl(0 0% 0% / 0.22);
+}
+
+.uber {
+  --background: hsl(0 0% 0%);
+  --foreground: hsl(0 0% 100%);
+  --card: hsl(0 0% 8%);
+  --card-foreground: hsl(0 0% 100%);
+  --popover: hsl(0 0% 8%);
+  --popover-foreground: hsl(0 0% 100%);
+  --primary: hsl(0 0% 0%);
+  --primary-foreground: hsl(0 0% 100%);
+  --secondary: hsl(0 0% 20%);
+  --secondary-foreground: hsl(0 0% 100%);
+  --muted: hsl(0 0% 20%);
+  --muted-foreground: hsl(0 0% 70%);
+  --accent: hsl(188 69% 44%);
+  --accent-foreground: hsl(0 0% 0%);
+  --destructive: hsl(0 80% 50%);
+  --destructive-foreground: hsl(0 0% 100%);
+  --border: hsl(0 0% 20%);
+  --input: hsl(0 0% 20%);
+  --ring: hsl(188 69% 44%);
+  --chart-1: hsl(188 69% 44%);
+  --chart-2: hsl(0 0% 100%);
+  --chart-3: hsl(0 0% 70%);
+  --chart-4: hsl(188 69% 30%);
+  --chart-5: hsl(0 0% 50%);
+  --sidebar: hsl(0 0% 0%);
+  --sidebar-foreground: hsl(0 0% 100%);
+  --sidebar-primary: hsl(0 0% 0%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(188 69% 44%);
+  --sidebar-accent-foreground: hsl(0 0% 0%);
+  --sidebar-border: hsl(0 0% 20%);
+  --sidebar-ring: hsl(188 69% 44%);
+  --font-sans: "UberMove", "Helvetica Neue", Arial, sans-serif;
+  --font-serif: Merriweather, serif;
+  --font-mono: "Courier New", monospace;
   --radius: 0.625rem;
   --shadow-2xs: 0px 6px 12px -3px hsl(0 0% 0% / 0.04);
   --shadow-xs: 0px 6px 12px -3px hsl(0 0% 0% / 0.04);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -32,7 +32,7 @@ export function Providers({ children }: { children: ReactNode }) {
         defaultTheme="system"
         enableSystem={true}
         disableTransitionOnChange
-        themes={["light", "dark", "sunset", "black"]}
+        themes={["light", "dark", "sunset", "black", "uber"]}
       >
         <MCPProvider>
           <SidebarProvider defaultOpen={sidebarOpen} open={sidebarOpen} onOpenChange={setSidebarOpen}>

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -141,7 +141,7 @@ const components: Partial<Components> = {
   ),
   blockquote: ({ node, children, ...props }) => (
     <blockquote
-      className="border-l-2 border-zinc-200 dark:border-zinc-700 black:border-zinc-700 pl-2 md:pl-3 my-1.5 italic text-zinc-600 dark:text-zinc-400 black:text-zinc-400 text-sm sm:text-base"
+      className="border-l-2 border-zinc-200 dark:border-zinc-700 black:border-zinc-700 uber:border-zinc-700 pl-2 md:pl-3 my-1.5 italic text-zinc-600 dark:text-zinc-400 black:text-zinc-400 uber:text-zinc-400 text-sm sm:text-base"
       {...props}
     >
       {children}
@@ -150,7 +150,7 @@ const components: Partial<Components> = {
   a: ({ node, children, ...props }) => (
     // @ts-expect-error error
     <Link
-      className="text-blue-500 hover:underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 black:text-blue-400 black:hover:text-blue-300 transition-colors break-words"
+      className="text-blue-500 hover:underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 black:text-blue-400 black:hover:text-blue-300 uber:text-blue-400 uber:hover:text-blue-300 transition-colors break-words"
       target="_blank"
       rel="noreferrer"
       {...props}
@@ -160,7 +160,7 @@ const components: Partial<Components> = {
   ),
   h1: ({ node, children, ...props }) => (
     <h1
-      className="text-xl md:text-2xl font-semibold mt-3 mb-1.5 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 break-words"
+      className="text-xl md:text-2xl font-semibold mt-3 mb-1.5 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 uber:text-zinc-200 break-words"
       {...props}
     >
       {children}
@@ -168,7 +168,7 @@ const components: Partial<Components> = {
   ),
   h2: ({ node, children, ...props }) => (
     <h2
-      className="text-lg md:text-xl font-semibold mt-2.5 mb-1.5 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 break-words"
+      className="text-lg md:text-xl font-semibold mt-2.5 mb-1.5 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 uber:text-zinc-200 break-words"
       {...props}
     >
       {children}
@@ -176,7 +176,7 @@ const components: Partial<Components> = {
   ),
   h3: ({ node, children, ...props }) => (
     <h3
-      className="text-base md:text-lg font-semibold mt-2 mb-1 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 break-words"
+      className="text-base md:text-lg font-semibold mt-2 mb-1 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 uber:text-zinc-200 break-words"
       {...props}
     >
       {children}
@@ -184,7 +184,7 @@ const components: Partial<Components> = {
   ),
   h4: ({ node, children, ...props }) => (
     <h4
-      className="text-sm md:text-base font-semibold mt-2 mb-1 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 break-words"
+      className="text-sm md:text-base font-semibold mt-2 mb-1 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 uber:text-zinc-200 break-words"
       {...props}
     >
       {children}
@@ -192,7 +192,7 @@ const components: Partial<Components> = {
   ),
   h5: ({ node, children, ...props }) => (
     <h5
-      className="text-xs md:text-sm font-semibold mt-2 mb-1 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 break-words"
+      className="text-xs md:text-sm font-semibold mt-2 mb-1 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 uber:text-zinc-200 break-words"
       {...props}
     >
       {children}
@@ -200,7 +200,7 @@ const components: Partial<Components> = {
   ),
   h6: ({ node, children, ...props }) => (
     <h6
-      className="text-xs font-semibold mt-2 mb-0.5 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 break-words"
+      className="text-xs font-semibold mt-2 mb-0.5 text-zinc-800 dark:text-zinc-200 black:text-zinc-200 uber:text-zinc-200 break-words"
       {...props}
     >
       {children}
@@ -209,7 +209,7 @@ const components: Partial<Components> = {
   table: ({ node, children, ...props }) => (
     <div className="my-1.5 overflow-x-auto w-full max-w-full">
       <table
-        className="min-w-full divide-y divide-zinc-200 dark:divide-zinc-700 black:divide-zinc-700 text-sm"
+        className="min-w-full divide-y divide-zinc-200 dark:divide-zinc-700 black:divide-zinc-700 uber:divide-zinc-700 text-sm"
         {...props}
       >
         {children}
@@ -218,7 +218,7 @@ const components: Partial<Components> = {
   ),
   thead: ({ node, children, ...props }) => (
     <thead
-      className="bg-zinc-50 dark:bg-zinc-800/50 black:bg-zinc-800/50"
+      className="bg-zinc-50 dark:bg-zinc-800/50 black:bg-zinc-800/50 uber:bg-zinc-800/50"
       {...props}
     >
       {children}
@@ -226,7 +226,7 @@ const components: Partial<Components> = {
   ),
   tbody: ({ node, children, ...props }) => (
     <tbody
-      className="divide-y divide-zinc-200 dark:divide-zinc-700 black:divide-zinc-700 bg-white dark:bg-transparent black:bg-transparent"
+      className="divide-y divide-zinc-200 dark:divide-zinc-700 black:divide-zinc-700 uber:divide-zinc-700 bg-white dark:bg-transparent black:bg-transparent uber:bg-transparent"
       {...props}
     >
       {children}
@@ -234,7 +234,7 @@ const components: Partial<Components> = {
   ),
   tr: ({ node, children, ...props }) => (
     <tr
-      className="transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/30 black:hover:bg-zinc-800/30"
+      className="transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/30 black:hover:bg-zinc-800/30 uber:hover:bg-zinc-800/30"
       {...props}
     >
       {children}
@@ -242,7 +242,7 @@ const components: Partial<Components> = {
   ),
   th: ({ node, children, ...props }) => (
     <th
-      className="px-3 py-1.5 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 black:text-zinc-400 uppercase tracking-wider"
+      className="px-3 py-1.5 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 black:text-zinc-400 uber:text-zinc-400 uppercase tracking-wider"
       {...props}
     >
       {children}
@@ -255,7 +255,7 @@ const components: Partial<Components> = {
   ),
   hr: ({ node, ...props }) => (
     <hr
-      className="my-1.5 border-zinc-200 dark:border-zinc-700 black:border-zinc-700"
+      className="my-1.5 border-zinc-200 dark:border-zinc-700 black:border-zinc-700 uber:border-zinc-700"
       {...props}
     />
   ),

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -27,9 +27,9 @@ export function ThemeToggle({
           className={cn(`rounded-md h-8 w-8`, className)}
           {...props}
         >
-          <Flame className="h-4 w-4 rotate-0 scale-100 transition-all light:scale-0 light:-rotate-90 black:scale-0 black:-rotate-90 hover:text-sidebar-accent" />
-          <Sun className="absolute h-4 w-4 rotate-90 scale-0 transition-all light:rotate-0 light:scale-100 black:scale-0 black:rotate-0 hover:text-sidebar-accent" />
-          <CircleDashed className="absolute h-4 w-4 rotate-90 scale-0 transition-all black:rotate-0 black:scale-100 light:scale-0 light:rotate-0 hover:text-sidebar-accent" />
+          <Flame className="h-4 w-4 rotate-0 scale-100 transition-all light:scale-0 light:-rotate-90 black:scale-0 black:-rotate-90 uber:scale-0 uber:-rotate-90 hover:text-sidebar-accent" />
+          <Sun className="absolute h-4 w-4 rotate-90 scale-0 transition-all light:rotate-0 light:scale-100 black:scale-0 black:rotate-0 uber:scale-0 uber:rotate-0 hover:text-sidebar-accent" />
+          <CircleDashed className="absolute h-4 w-4 rotate-90 scale-0 transition-all black:rotate-0 black:scale-100 uber:rotate-0 uber:scale-100 light:scale-0 light:rotate-0 hover:text-sidebar-accent" />
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
@@ -50,6 +50,10 @@ export function ThemeToggle({
         <DropdownMenuItem onSelect={() => setTheme("sunset")}>
           <Sun className="mr-2 h-4 w-4" />
           <span>Sunset</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setTheme("uber")}>
+          <CircleDashed className="mr-2 h-4 w-4" />
+          <span>Uber</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- add new `uber` theme variables in global CSS
- include `uber` in available theme options
- update theme toggle with Uber option
- style Markdown elements for the new theme

## Testing
- `npx next lint` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688380ac5ea48323a8bef5ea5bf255fa